### PR TITLE
Update cairo.c

### DIFF
--- a/cairo.c
+++ b/cairo.c
@@ -614,8 +614,8 @@ ZEND_END_ARG_INFO()
 #if defined(CAIRO_HAS_FT_FONT) && defined(HAVE_FREETYPE)
 
 const char* php_cairo_get_ft_error(int error TSRMLS_DC) {
-	int i;
-	php_cairo_ft_error *current_error = php_cairo_ft_errors;
+	
+        php_cairo_ft_error *current_error = (php_cairo_ft_error *)php_cairo_ft_errors;
 
 	while (current_error->err_msg != NULL) {
 		if (current_error->err_code == error) {


### PR DESCRIPTION
removes warning: initialization discards âconstâ qualifier from pointer target type [enabled by default]
