### PR TITLE
Fixed warning messages during build process,

### DIFF
--- a/cairo.c
+++ b/cairo.c
@@ -614,8 +614,7 @@ ZEND_END_ARG_INFO()
 #if defined(CAIRO_HAS_FT_FONT) && defined(HAVE_FREETYPE)
 
 const char* php_cairo_get_ft_error(int error TSRMLS_DC) {
-	int i;
-	php_cairo_ft_error *current_error = php_cairo_ft_errors;
+	const php_cairo_ft_error *current_error = php_cairo_ft_errors;
 
 	while (current_error->err_msg != NULL) {
 		if (current_error->err_code == error) {
@@ -626,7 +625,7 @@ const char* php_cairo_get_ft_error(int error TSRMLS_DC) {
 	return NULL;
 }
 
-#endif	
+#endif
 
 /* {{{ proto int cairo_version(void) 
        Returns an integer version number of the cairo library being used */

--- a/cairo_context.c
+++ b/cairo_context.c
@@ -2976,7 +2976,6 @@ static zend_object_value cairo_context_object_new(zend_class_entry *ce TSRMLS_DC
 {
 	zend_object_value retval;
 	cairo_context_object *context;
-	zval *temp;
 
 	context = ecalloc(1, sizeof(cairo_context_object));
 

--- a/cairo_font_face.c
+++ b/cairo_font_face.c
@@ -116,7 +116,6 @@ zend_object_value cairo_font_face_object_new(zend_class_entry *ce TSRMLS_DC)
 {
 	zend_object_value retval;
 	cairo_font_face_object *font_face;
-	zval *temp;
 
 	font_face = ecalloc(1, sizeof(cairo_font_face_object));
 

--- a/cairo_font_options.c
+++ b/cairo_font_options.c
@@ -74,7 +74,6 @@ static zend_object_value cairo_font_options_object_new(zend_class_entry *ce TSRM
 {
 	zend_object_value retval;
 	cairo_font_options_object *font_options;
-	zval *temp;
 
 	font_options = ecalloc(1, sizeof(cairo_font_options_object));
 	font_options->font_options = NULL;

--- a/cairo_ft_font.c
+++ b/cairo_ft_font.c
@@ -203,7 +203,7 @@ PHP_FUNCTION(cairo_ft_font_face_create)
 	error = php_cairo_create_ft_font_face(font_face_object, stream, owned_stream, load_flags, 0 TSRMLS_CC);
 
 	if (error) {
-		char *err_string = php_cairo_get_ft_error(error TSRMLS_CC);
+		const char *err_string = php_cairo_get_ft_error(error TSRMLS_CC);
 		zend_error(E_WARNING, "cairo_ft_font_face_create(): An error occurred opening the file: %s", err_string);
 		RETURN_NULL();
 	} 
@@ -328,7 +328,6 @@ zend_object_value cairo_ft_font_face_object_new(zend_class_entry *ce TSRMLS_DC)
 {
 	zend_object_value retval;
 	cairo_ft_font_face_object *font_face;
-	zval *temp;
 
 	font_face = ecalloc(1, sizeof(cairo_ft_font_face_object));
 	font_face->ft_stream = NULL;

--- a/cairo_matrix.c
+++ b/cairo_matrix.c
@@ -523,7 +523,6 @@ static zend_object_value cairo_matrix_object_new(zend_class_entry *ce TSRMLS_DC)
 {
 	zend_object_value retval;
 	cairo_matrix_object *matrix;
-	zval *temp;
 
 	matrix = ecalloc(1, sizeof(cairo_matrix_object));
 

--- a/cairo_path.c
+++ b/cairo_path.c
@@ -45,7 +45,6 @@ static zend_object_value cairo_path_object_new(zend_class_entry *ce TSRMLS_DC)
 {
 	zend_object_value retval;
 	cairo_path_object *path;
-	zval *temp;
 
 	path = ecalloc(1, sizeof(cairo_path_object));
 

--- a/cairo_pattern.c
+++ b/cairo_pattern.c
@@ -934,7 +934,6 @@ static zend_object_value cairo_pattern_object_new(zend_class_entry *ce TSRMLS_DC
 {
 	zend_object_value retval;
 	cairo_pattern_object *pattern;
-	zval *temp;
 
 	pattern = ecalloc(1, sizeof(cairo_pattern_object));
 

--- a/cairo_scaled_font.c
+++ b/cairo_scaled_font.c
@@ -515,7 +515,6 @@ static zend_object_value cairo_scaled_font_object_new(zend_class_entry *ce TSRML
 {
 	zend_object_value retval;
 	cairo_scaled_font_object *scaled_font;
-	zval *temp;
 
 	scaled_font = ecalloc(1, sizeof(cairo_scaled_font_object));
 

--- a/cairo_surface.c
+++ b/cairo_surface.c
@@ -82,7 +82,7 @@ PHP_FUNCTION(cairo_surface_create_similar)
 	zval *surface_zval = NULL;
 	cairo_surface_object *surface_object, *new_surface_object;
 	cairo_surface_t *new_surface;
-	long content;
+	int content;
 	double width, height;
 
 	PHP_CAIRO_ERROR_HANDLING(FALSE)
@@ -272,7 +272,7 @@ PHP_FUNCTION(cairo_surface_mark_dirty_rectangle)
 {
 	zval *surface_zval = NULL;
 	cairo_surface_object *surface_object;
-	double x = 0.0, y = 0.0, width = 0.0, height = 0.0;
+	float x = 0.0, y = 0.0, width = 0.0, height = 0.0;
 
 	PHP_CAIRO_ERROR_HANDLING(FALSE)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Odddd", &surface_zval, cairo_ce_cairosurface, &x, &y, &width, &height) == FAILURE) {
@@ -601,7 +601,6 @@ zend_object_value cairo_surface_object_new(zend_class_entry *ce TSRMLS_DC)
 {
 	zend_object_value retval;
 	cairo_surface_object *surface;
-	zval *temp;
 
 	surface = ecalloc(1, sizeof(cairo_surface_object));
 

--- a/cairo_win32_font.c
+++ b/cairo_win32_font.c
@@ -275,7 +275,6 @@ zend_object_value cairo_win32_font_face_create_new(zend_class_entry *ce TSRMLS_D
 {
     zend_object_value retval;
     cairo_win32_font_face_object *font_face;
-    zval *temp;
 
     font_face = ecalloc(1, sizeof(cairo_win32_font_face_object));
     font_face->std.ce = ce;


### PR DESCRIPTION
-C4101: Because of unused variable (zval).
-C4090: Missing 'const' keyword.
-C4244: data loss, happened due to conversion of data type.
