### PR TITLE
Fix segfault in freetype

### DIFF
--- a/cairo.c
+++ b/cairo.c
@@ -35,23 +35,9 @@ zend_class_entry *cairo_ce_cairo;
 zend_object_handlers cairo_std_object_handlers;
 
 #if defined(CAIRO_HAS_FT_FONT) && defined(HAVE_FREETYPE)
-ZEND_DECLARE_MODULE_GLOBALS(cairo)
 
 const php_cairo_ft_error php_cairo_ft_errors[] =
 #include FT_ERRORS_H
-
-PHP_GINIT_FUNCTION(cairo)
-{
-	cairo_globals->ft_lib = NULL;
-}
-
-PHP_GSHUTDOWN_FUNCTION(cairo)
-{
-	if (cairo_globals->ft_lib != NULL) {
-		FT_Done_FreeType(cairo_globals->ft_lib);
-	}
-}
-
 
 #endif
 
@@ -1192,15 +1178,7 @@ zend_module_entry cairo_module_entry = {
 	NULL,
 	PHP_MINFO(cairo),
 	PHP_CAIRO_VERSION,
-#if defined(CAIRO_HAS_FT_FONT) && defined(HAVE_FREETYPE)
-	PHP_MODULE_GLOBALS(cairo),
-	PHP_GINIT(cairo),
-	PHP_GSHUTDOWN(cairo), 
-	NULL,
-	STANDARD_MODULE_PROPERTIES_EX
-#else
 	STANDARD_MODULE_PROPERTIES
-#endif
 };
 /* }}} */
 

--- a/php_cairo.h
+++ b/php_cairo.h
@@ -138,6 +138,7 @@ typedef struct _cairo_font_face_object {
 typedef struct _cairo_ft_font_face_object {
 	zend_object std;
 	cairo_font_face_t *font_face;
+	FT_Library ft_lib;
 	FT_Stream ft_stream;
 	FT_Face ft_face;
 	cairo_user_data_key_t key;
@@ -161,22 +162,7 @@ PHP_MINIT_FUNCTION(cairo);
 PHP_MINFO_FUNCTION(cairo);
 PHP_MSHUTDOWN_FUNCTION(cairo);
 
-/* Globals */
 #if defined(CAIRO_HAS_FT_FONT) && defined(HAVE_FREETYPE)
-ZEND_BEGIN_MODULE_GLOBALS(cairo)
-	/* Freetype library */
-	FT_Library ft_lib;
-ZEND_END_MODULE_GLOBALS(cairo)
-
-
-#ifdef ZTS
-# define CAIROG(v) TSRMG(cairo_globals_id, zend_cairo_globals *, v)
-#else
-# define CAIROG(v) (cairo_globals.v)
-#endif
-
-ZEND_EXTERN_MODULE_GLOBALS(cairo)
-
 
 typedef struct _php_cairo_ft_error {
 	int err_code;

--- a/tests/CairoFontFace/CairoFtFontFace/__construct.phpt
+++ b/tests/CairoFontFace/CairoFtFontFace/__construct.phpt
@@ -63,6 +63,6 @@ object(CairoFtFontFace)#2 (0) {
 string(86) "CairoFtFontFace::__construct() expects parameter 1 to be a string or a stream resource"
 object(CairoFtFontFace)#2 (0) {
 }
-string(66) "CairoFtFontFace::__construct(): An error occurred opening the file"
+string(91) "CairoFtFontFace::__construct(): An error occurred opening the file invalid stream operation"
 object(CairoFtFontFace)#2 (0) {
 }


### PR DESCRIPTION
When in doubt do it the hard way
instead of messing with globals
have a single freetype library for each freetype font instance created
