### PR TITLE
fixed destruction of FT-fonts and associated resources

### DIFF
--- a/php_cairo.h
+++ b/php_cairo.h
@@ -83,6 +83,12 @@ typedef struct _cairo_glyph_object {
 	cairo_glyph_t *glyph;
 } cairo_glyph_object;
 
+typedef struct _pecl_ft_container {
+	FT_Library ft_lib;
+    FT_Face ft_face;
+    FT_Stream ft_stream;
+} pecl_ft_container;
+
 typedef struct _cairo_context_object {
 	zend_object std;
 	zval *surface;
@@ -138,9 +144,7 @@ typedef struct _cairo_font_face_object {
 typedef struct _cairo_ft_font_face_object {
 	zend_object std;
 	cairo_font_face_t *font_face;
-	FT_Library ft_lib;
-	FT_Stream ft_stream;
-	FT_Face ft_face;
+    stream_closure *closure;
 	cairo_user_data_key_t key;
 } cairo_ft_font_face_object;
 #endif
@@ -522,7 +526,6 @@ extern cairo_status_t php_cairo_read_func(void *closure, const unsigned char *da
 extern cairo_status_t php_cairo_write_func(void *closure, const unsigned char *data, unsigned int length);
 #if defined(CAIRO_HAS_FT_FONT) && defined(HAVE_FREETYPE)
 static unsigned long php_cairo_ft_read_func(FT_Stream stream, unsigned long offset, unsigned char* buffer, unsigned long count);
-extern void php_cairo_ft_close_stream(FT_Stream stream);
 #endif
 
 extern zend_object_value cairo_font_face_object_new(zend_class_entry *ce TSRMLS_DC);


### PR DESCRIPTION
This pull request is in response to issues #2 and 'cairo font cache poisoning' that was introduced with the solution in #15 by @medic123de.

Background:

In january we had issues based on the last changes in master, that separated the ft_lib. @medic123de produced a patch, that removed the core file issue and all seemed good.

A couple weeks ago, we discovered, that if one is creating a lot of pictures with text, sometimes, the text is not visible at all or single glyphs are missing. 

After haveing a simple script to reproduce the issue, searching the web about simliar symptons when using cairo and ft-fonts, and looking at the code in pecl cairo, I found the current master (and the patch from @medic123de) do not adhere to what should be done about freeing the FT resources in a cairo environemt. http://cairo.cairographics.narkive.com/qINWvRx7/issue-with-cairo-font-cache

As long as cairo is holding a reference to the font used in its internal font cache, one can not call FT_Done_Face in its own code. 
Calling FT_Done_Face as callback in cairo_font_face_set_user_data when the FT_Lib might already have been destroyed in cairo_ft_font_face_object_destroy caused the core files.

To address these issues, I created a patch and introduced a new function cairo_user_data_callback_ft_free, that contains everything that needs to be freed after cairo is done with this specific ft-font. The memory associated needs to be allocated to last longer then the request itself, aka in the process scope, otherwise, the cairo font cache would again hold references to already freed memory.

I have attached a simple script for reproduction. It is not neccessary to actualy draw text. It is enough to check the fontExtends for invalid values.

With the current master, this script should produce core files from time to time (cent os 6 + php 54 from remi repositories). With the patch #15 from @medic123de, after a few requests per php-fpm child, the error counter which is outputed into the error_log will increase.

With this patch, there should be neither core files, nor an increase in memory, or text drawn with missing glyphs.

    <?php
    $surface = new \CairoImageSurface(CairoFormat::ARGB32, 100, 10);
    $context = new \CairoContext($surface);


    $errorCounter = 0;
    $counter = 0;

    for ($i = 0; $i < 600; ++$i, ++$counter) {
        $fontFace = new \CairoFtFontFace(dirname(__FILE__) . "/arial.ttf");
        $context->setFontFace($fontFace);
        $fontExtents = $context->fontExtents();
        if ($fontExtents['height'] == 0) {
            $errorCounter++;
        }
    }

    error_log(getmypid() . ' Number of errors: ' . $errorCounter . '/' . $counter);

    $surface->flush();
    $surface->finish();






