### PR TITLE
Php7.0 fixes for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ build_script:
   - echo Building PHP [%PHP_VERSION%]
   - '%PHP_SDK%\bin\phpsdk_setvars'
   - buildconf
-  - configure --disable-all --enable-cli --enable-eos_datastructures --with-cairo %CONFIGURE_EXTRA%
+  - configure --disable-all --enable-zlib --enable-cli --enable-eos_datastructures --with-cairo %CONFIGURE_EXTRA%
   - nmake
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,12 +57,12 @@ build_script:
   - echo Building PHP [%PHP_VERSION%]
   - '%PHP_SDK%\bin\phpsdk_setvars'
   - buildconf
-  - configure --disable-all --enable-zlib --enable-cli --enable-eos_datastructures --with-cairo %CONFIGURE_EXTRA%
+  - configure --disable-all --enable-cli --enable-zlib --enable-eos_datastructures=shared --with-cairo=shared %CONFIGURE_EXTRA%
   - nmake
 
 after_build:
   - cd %OUTDIR%
-  - 7z a %ARTIFACT_NAME% cairo.dll php_cairo.dll
+  - 7z a %ARTIFACT_NAME% cairo.dll php_cairo.dll php_eos_datastructures.dll
   - ps: Push-AppveyorArtifact $env:ARTIFACT_NAME
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-  - ARTIFACT_NAME: cairo_vc14_php7_%Platform%_ts.zip
-    OUTDIR: Release_TS
-    V8_ASSETS: cairo-1.14.6-%Platform%.zip
+#  - ARTIFACT_NAME: cairo_vc14_php7_%Platform%_ts.zip
+#    OUTDIR: Release_TS
+#    V8_ASSETS: cairo-1.14.6-%Platform%.zip
   - ARTIFACT_NAME: cairo_vc14_php7_%Platform%_nts.zip
     OUTDIR: Release
     CONFIGURE_EXTRA: --disable-zts

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,67 @@
+environment:
+  matrix:
+  - ARTIFACT_NAME: cairo_vc14_php7_%Platform%_ts.zip
+    OUTDIR: Release_TS
+    V8_ASSETS: cairo-1.14.6-%Platform%.zip
+  - ARTIFACT_NAME: cairo_vc14_php7_%Platform%_nts.zip
+    OUTDIR: Release
+    CONFIGURE_EXTRA: --disable-zts
+    V8_ASSETS: cairo-1.14.6-%Platform%.zip
+
+  PHP_VERSION: 7.0.18
+  PHP_SDK: c:\projects\php-sdk
+
+os: Windows Server 2012
+clone_folder: c:\projects\php-sdk\cairo-ci\vc14\%Platform%\php\ext\cairo
+
+platform:
+  - x64
+  - x86
+
+install:
+  - cd %PHP_SDK%
+  - curl -fSL -o php-sdk-binary-tools-20110915.zip "http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip"
+  - 7z.exe x php-sdk-binary-tools-20110915.zip
+  - call bin\phpsdk_setvars.bat
+  - call bin\phpsdk_buildtree.bat cairo-ci
+  - cd cairo-ci\vc14\%Platform%
+  - md deps
+  - cd deps
+  - curl -fSL -o %V8_ASSETS% "https://phpdev.toolsforresearch.com/%V8_ASSETS%"
+  - 7z.exe x %V8_ASSETS%
+  - cd ..
+  - curl -fSL -o "php-%PHP_VERSION%.tar.gz" "http://us1.php.net/distributions/php-%PHP_VERSION%.tar.gz"
+  - ren php php-%PHP_VERSION%
+  - 7z.exe x php-%PHP_VERSION%.tar.gz -y
+  - 7z.exe x php-%PHP_VERSION%.tar -y | find /v "Extracting"
+  - cd php-%PHP_VERSION%
+  - IF "%Platform%" == "x64" SET OUTDIR=x64\%OUTDIR%
+  - mkdir %OUTDIR%
+  - move ..\deps\bin\*.dll %OUTDIR%\
+
+build_script:
+  - ps: >-
+      If ($env:Platform -Match "x86") {
+        $env:VCVARS_PLATFORM="x86"
+        $env:ENV_PLATFORM="x86"
+      } Else {
+        $env:VCVARS_PLATFORM="amd64"
+        $env:ENV_PLATFORM="x64"
+      }
+  - call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %VCVARS_PLATFORM%
+  - echo Building PHP [%PHP_VERSION%]
+  - '%PHP_SDK%\bin\phpsdk_setvars'
+  - buildconf
+  - configure --disable-all --enable-cli --with-cairo %CONFIGURE_EXTRA%
+  - nmake
+
+after_build:
+  - cd %OUTDIR%
+  - 7z a %ARTIFACT_NAME% cairo.dll php_cairo.dll
+  - ps: Push-AppveyorArtifact $env:ARTIFACT_NAME
+
+test_script:
+
+on_finish:
+
+deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,10 @@ install:
   - call bin\phpsdk_setvars.bat
   - call bin\phpsdk_buildtree.bat cairo-ci
   - cd cairo-ci\vc14\%Platform%
+  - if not exist php mkdir php
+  - if not exist php\ext mkdir php\ext
+  - cd php\ext
+  - git clone https://github.com/eosforphp/datastructures.git eos_datastructures
   - md deps
   - cd deps
   - curl -fSL -o %V8_ASSETS% "https://phpdev.toolsforresearch.com/%V8_ASSETS%"
@@ -52,7 +56,7 @@ build_script:
   - echo Building PHP [%PHP_VERSION%]
   - '%PHP_SDK%\bin\phpsdk_setvars'
   - buildconf
-  - configure --disable-all --enable-cli --with-cairo %CONFIGURE_EXTRA%
+  - configure --disable-all --enable-cli --enable-eos_datastructures --with-cairo %CONFIGURE_EXTRA%
   - nmake
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ environment:
   matrix:
   - ARTIFACT_NAME: cairo_vc14_php7_%Platform%_ts.zip
     OUTDIR: Release_TS
-    V8_ASSETS: cairo-1.14.8-vc14-%Platform%.zip
+    V8_ASSETS: cairo-1.14.6-%Platform%.zip
   - ARTIFACT_NAME: cairo_vc14_php7_%Platform%_nts.zip
     OUTDIR: Release
     CONFIGURE_EXTRA: --disable-zts
-    V8_ASSETS: cairo-1.14.8-vc14-%Platform%.zip
+    V8_ASSETS: cairo-1.14.6-%Platform%.zip
 
   PHP_VERSION: 7.0.18
   PHP_SDK: c:\projects\php-sdk
@@ -32,7 +32,7 @@ install:
   - cd ..\..
   - md deps
   - cd deps
-  - curl -fSL -o %V8_ASSETS% "http://windows.php.net/downloads/pecl/deps/%V8_ASSETS%"
+  - curl -fSL -o %V8_ASSETS% "https://phpdev.toolsforresearch.com/%V8_ASSETS%"
   - 7z.exe x %V8_ASSETS%
   - cd ..
   - curl -fSL -o "php-%PHP_VERSION%.tar.gz" "http://us1.php.net/distributions/php-%PHP_VERSION%.tar.gz"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ environment:
   matrix:
   - ARTIFACT_NAME: cairo_vc14_php7_%Platform%_ts.zip
     OUTDIR: Release_TS
-    V8_ASSETS: cairo-1.14.6-%Platform%.zip
+    V8_ASSETS: cairo-1.14.8-vc14-%Platform%.zip
   - ARTIFACT_NAME: cairo_vc14_php7_%Platform%_nts.zip
     OUTDIR: Release
     CONFIGURE_EXTRA: --disable-zts
-    V8_ASSETS: cairo-1.14.6-%Platform%.zip
+    V8_ASSETS: cairo-1.14.8-vc14-%Platform%.zip
 
   PHP_VERSION: 7.0.18
   PHP_SDK: c:\projects\php-sdk
@@ -32,7 +32,7 @@ install:
   - cd ..\..
   - md deps
   - cd deps
-  - curl -fSL -o %V8_ASSETS% "https://phpdev.toolsforresearch.com/%V8_ASSETS%"
+  - curl -fSL -o %V8_ASSETS% "http://windows.php.net/downloads/pecl/deps/%V8_ASSETS%"
   - 7z.exe x %V8_ASSETS%
   - cd ..
   - curl -fSL -o "php-%PHP_VERSION%.tar.gz" "http://us1.php.net/distributions/php-%PHP_VERSION%.tar.gz"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ clone_folder: c:\projects\php-sdk\cairo-ci\vc14\%Platform%\php\ext\cairo
 
 platform:
   - x64
-  - x86
+  # - x86
 
 install:
   - cd %PHP_SDK%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-#  - ARTIFACT_NAME: cairo_vc14_php7_%Platform%_ts.zip
-#    OUTDIR: Release_TS
-#    V8_ASSETS: cairo-1.14.6-%Platform%.zip
+  - ARTIFACT_NAME: cairo_vc14_php7_%Platform%_ts.zip
+    OUTDIR: Release_TS
+    V8_ASSETS: cairo-1.14.6-%Platform%.zip
   - ARTIFACT_NAME: cairo_vc14_php7_%Platform%_nts.zip
     OUTDIR: Release
     CONFIGURE_EXTRA: --disable-zts

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ clone_folder: c:\projects\php-sdk\cairo-ci\vc14\%Platform%\php\ext\cairo
 
 platform:
   - x64
-  # - x86
+  - x86
 
 install:
   - cd %PHP_SDK%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ install:
   - if not exist php\ext mkdir php\ext
   - cd php\ext
   - git clone https://github.com/eosforphp/datastructures.git eos_datastructures
+  - cd ..\..
   - md deps
   - cd deps
   - curl -fSL -o %V8_ASSETS% "https://phpdev.toolsforresearch.com/%V8_ASSETS%"

--- a/config.w32
+++ b/config.w32
@@ -3,49 +3,63 @@
 ARG_WITH("cairo", "Cairo Graphics Library Bindings", "no");
 
 if (PHP_CAIRO != "no") {
+	configure_module_dirname = configure_module_dirname + "\\src";
+	var PHP_CAIRO_SRC_ARRAY = glob(configure_module_dirname + "/*.c");
+	var PHP_CAIRO_SOURCES="";
+	for (var i=0; i<PHP_CAIRO_SRC_ARRAY.length; ++i) {
+		var basename = FSO.GetFileName(PHP_CAIRO_SRC_ARRAY[i]);
+		PHP_CAIRO_SOURCES = PHP_CAIRO_SOURCES + " " + basename;
+	}
 	if (CHECK_HEADER_ADD_INCLUDE("cairo/cairo.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true) &&
 		CHECK_HEADER_ADD_INCLUDE("ft2build.h", "CFLAGS_CAIRO", PHP_CAIRO + ";" + PHP_PHP_BUILD + "\\include" + ";" + PHP_PHP_BUILD + "\\include\\freetype")) {
 		/* Check for static lib first, because that will need an extra define */
 		if (CHECK_LIB("cairo_a.lib", "cairo", PHP_CAIRO + "\\lib")) {
-			/* We don't care if this fails, but if it does exists, we need to link */
-			CHECK_LIB("fontconfig.lib", "cairo", PHP_CAIRO + "\\lib");
-			CHECK_HEADER_ADD_INCLUDE("fontconfig/fontconfig.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true);
-
+			if (CHECK_LIB("libpng_a.lib", "cairo", PHP_CAIRO + "\\lib")) {
+				CHECK_HEADER_ADD_INCLUDE("png.h", "CFLAGS_CAIRO", PHP_CAIRO + ";" + PHP_PHP_BUILD + "\\include" + ";" + PHP_PHP_BUILD + "\\include\\png");
+			}
 			if (CHECK_LIB("freetype_a.lib", "cairo", PHP_CAIRO + "\\lib")) {
 				CHECK_HEADER_ADD_INCLUDE("freetype/freetype.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true);
-				AC_DEFINE("HAVE_FREETYPE", 1);
+				//AC_DEFINE("HAVE_FREETYPE", 1);
+                //ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_FREETYPE");
+				if (CHECK_LIB("fontconfig.lib", "cairo", PHP_CAIRO + "\\lib") &&
+					CHECK_HEADER_ADD_INCLUDE("fontconfig/fontconfig.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true)) {
+					//AC_DEFINE("CAIRO_HAS_FT_FONT", 1);
+				}
 			}
 			if (CHECK_LIB("Gdi32.lib", "cairo", PHP_CAIRO + "\\lib")) {
-				AC_DEFINE("HAVE_WIN32_FONT", 1);
+				//AC_DEFINE("HAVE_WIN32_FONT", 1);
+                //ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_WIN32_FONT");
 			}
 
-			EXTENSION("cairo", "cairo.c cairo_error.c cairo_context.c cairo_pattern.c cairo_matrix.c cairo_path.c \
-			cairo_surface.c cairo_image_surface.c cairo_svg_surface.c cairo_pdf_surface.c cairo_ps_surface.c \
-			cairo_font.c cairo_font_options.c cairo_font_face.c cairo_scaled_font.c cairo_ft_font.c \
-			cairo_recording_surface.c cairo_sub_surface.c cairo_win32_font.c");
+			EXTENSION("cairo", PHP_CAIRO_SOURCES);
+	        ADD_EXTENSION_DEP("cairo", "eos_datastructures");
 			ADD_FLAG("CFLAGS_CAIRO", "/D CAIRO_WIN32_STATIC_BUILD=1");
 
 			AC_DEFINE("HAVE_CAIRO", 1);
-			PHP_INSTALL_HEADERS("ext/cairo", "php_cairo_api.h");
+			PHP_INSTALL_HEADERS("ext/cairo", "src/php_cairo_api.h");
 		} else if (CHECK_LIB("cairo.lib", "cairo", PHP_CAIRO + "\\lib")) {
-			CHECK_LIB("fontconfig.lib", "cairo", PHP_CAIRO + "\\lib");
-			CHECK_HEADER_ADD_INCLUDE("fontconfig/fontconfig.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true);
-
+			if (CHECK_LIB("libpng_a.lib", "cairo", PHP_CAIRO + "\\lib")) {
+				CHECK_HEADER_ADD_INCLUDE("png.h", "CFLAGS_CAIRO", PHP_CAIRO + ";" + PHP_PHP_BUILD + "\\include" + ";" + PHP_PHP_BUILD + "\\include\\png");
+			}
 			if (CHECK_LIB("freetype_a.lib", "cairo", PHP_CAIRO + "\\lib")) {
 				CHECK_HEADER_ADD_INCLUDE("freetype/freetype.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true);
-				AC_DEFINE("HAVE_FREETYPE", 1);
+				//AC_DEFINE("HAVE_FREETYPE", 1);
+                //ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_FREETYPE");
+				if (CHECK_LIB("fontconfig.lib", "cairo", PHP_CAIRO + "\\lib") &&
+					CHECK_HEADER_ADD_INCLUDE("fontconfig/fontconfig.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true)) {
+					//AC_DEFINE("CAIRO_HAS_FT_FONT", 1);
+				}
 			}
 			if (CHECK_LIB("Gdi32.lib", "cairo", PHP_CAIRO + "\\lib")) {
-				AC_DEFINE("HAVE_WIN32_FONT", 1);
+				//AC_DEFINE("HAVE_WIN32_FONT", 1);
+                //ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_WIN32_FONT");
 			}
 
-			EXTENSION("cairo", "cairo.c cairo_error.c cairo_context.c cairo_pattern.c cairo_matrix.c cairo_path.c \
-			cairo_surface.c cairo_image_surface.c cairo_svg_surface.c cairo_pdf_surface.c cairo_ps_surface.c \
-			cairo_font.c cairo_font_options.c cairo_font_face.c cairo_scaled_font.c cairo_ft_font.c \
-			cairo_recording_surface.c cairo_sub_surface.c  cairo_win32_font.c");
+			EXTENSION("cairo", PHP_CAIRO_SOURCES);
+	        ADD_EXTENSION_DEP("cairo", "eos_datastructures");
 
 			AC_DEFINE("HAVE_CAIRO", 1);
-			PHP_INSTALL_HEADERS("ext/cairo", "php_cairo_api.h");
+			PHP_INSTALL_HEADERS("ext/cairo", "src/php_cairo_api.h");
 		} else {
 			WARNING('Could not find cairo.lib or cairo_a.lib; skipping');
 		}

--- a/config.w32
+++ b/config.w32
@@ -27,8 +27,8 @@ if (PHP_CAIRO != "no") {
                 }
             }
             if (CHECK_LIB("Gdi32.lib", "cairo", PHP_CAIRO + "\\lib")) {
-                //AC_DEFINE("HAVE_WIN32_FONT", 1);
-                //ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_WIN32_FONT");
+                AC_DEFINE("HAVE_WIN32_FONT", 1);
+                ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_WIN32_FONT");
             }
 
             EXTENSION("cairo", PHP_CAIRO_SOURCES);
@@ -51,8 +51,8 @@ if (PHP_CAIRO != "no") {
                 }
             }
             if (CHECK_LIB("Gdi32.lib", "cairo", PHP_CAIRO + "\\lib")) {
-                //AC_DEFINE("HAVE_WIN32_FONT", 1);
-                //ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_WIN32_FONT");
+                AC_DEFINE("HAVE_WIN32_FONT", 1);
+                ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_WIN32_FONT");
             }
 
             EXTENSION("cairo", PHP_CAIRO_SOURCES);

--- a/config.w32
+++ b/config.w32
@@ -21,49 +21,49 @@ if (PHP_CAIRO != "no") {
 				CHECK_HEADER_ADD_INCLUDE("freetype/freetype.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true);
 				//AC_DEFINE("HAVE_FREETYPE", 1);
                 //ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_FREETYPE");
-				if (CHECK_LIB("fontconfig.lib", "cairo", PHP_CAIRO + "\\lib") &&
-					CHECK_HEADER_ADD_INCLUDE("fontconfig/fontconfig.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true)) {
-					//AC_DEFINE("CAIRO_HAS_FT_FONT", 1);
-				}
-			}
-			if (CHECK_LIB("Gdi32.lib", "cairo", PHP_CAIRO + "\\lib")) {
-				//AC_DEFINE("HAVE_WIN32_FONT", 1);
+                if (CHECK_LIB("fontconfig.lib", "cairo", PHP_CAIRO + "\\lib") &&
+                    CHECK_HEADER_ADD_INCLUDE("fontconfig/fontconfig.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true)) {
+                    //AC_DEFINE("CAIRO_HAS_FT_FONT", 1);
+                }
+            }
+            if (CHECK_LIB("Gdi32.lib", "cairo", PHP_CAIRO + "\\lib")) {
+                //AC_DEFINE("HAVE_WIN32_FONT", 1);
                 //ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_WIN32_FONT");
-			}
+            }
 
-			EXTENSION("cairo", PHP_CAIRO_SOURCES);
-	        ADD_EXTENSION_DEP("cairo", "eos_datastructures");
-			ADD_FLAG("CFLAGS_CAIRO", "/D CAIRO_WIN32_STATIC_BUILD=1");
+            EXTENSION("cairo", PHP_CAIRO_SOURCES);
+            ADD_EXTENSION_DEP("cairo", "eos_datastructures");
+            ADD_FLAG("CFLAGS_CAIRO", "/D CAIRO_WIN32_STATIC_BUILD=1");
 
-			AC_DEFINE("HAVE_CAIRO", 1);
-			PHP_INSTALL_HEADERS("ext/cairo", "src/php_cairo_api.h");
-		} else if (CHECK_LIB("cairo.lib", "cairo", PHP_CAIRO + "\\lib")) {
-			if (CHECK_LIB("libpng_a.lib", "cairo", PHP_CAIRO + "\\lib")) {
-				CHECK_HEADER_ADD_INCLUDE("png.h", "CFLAGS_CAIRO", PHP_CAIRO + ";" + PHP_PHP_BUILD + "\\include" + ";" + PHP_PHP_BUILD + "\\include\\png");
-			}
-			if (CHECK_LIB("freetype_a.lib", "cairo", PHP_CAIRO + "\\lib")) {
-				CHECK_HEADER_ADD_INCLUDE("freetype/freetype.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true);
-				//AC_DEFINE("HAVE_FREETYPE", 1);
+            AC_DEFINE("HAVE_CAIRO", 1);
+            PHP_INSTALL_HEADERS("ext/cairo", "src/php_cairo_api.h");
+        } else if (CHECK_LIB("cairo.lib", "cairo", PHP_CAIRO + "\\lib")) {
+            if (CHECK_LIB("libpng_a.lib", "cairo", PHP_CAIRO + "\\lib")) {
+                CHECK_HEADER_ADD_INCLUDE("png.h", "CFLAGS_CAIRO", PHP_CAIRO + ";" + PHP_PHP_BUILD + "\\include" + ";" + PHP_PHP_BUILD + "\\include\\png");
+            }
+            if (CHECK_LIB("freetype_a.lib", "cairo", PHP_CAIRO + "\\lib")) {
+                CHECK_HEADER_ADD_INCLUDE("freetype/freetype.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true);
+                //AC_DEFINE("HAVE_FREETYPE", 1);
                 //ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_FREETYPE");
-				if (CHECK_LIB("fontconfig.lib", "cairo", PHP_CAIRO + "\\lib") &&
-					CHECK_HEADER_ADD_INCLUDE("fontconfig/fontconfig.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true)) {
-					//AC_DEFINE("CAIRO_HAS_FT_FONT", 1);
-				}
-			}
-			if (CHECK_LIB("Gdi32.lib", "cairo", PHP_CAIRO + "\\lib")) {
-				//AC_DEFINE("HAVE_WIN32_FONT", 1);
+                if (CHECK_LIB("fontconfig.lib", "cairo", PHP_CAIRO + "\\lib") &&
+                    CHECK_HEADER_ADD_INCLUDE("fontconfig/fontconfig.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true)) {
+                    //AC_DEFINE("CAIRO_HAS_FT_FONT", 1);
+                }
+            }
+            if (CHECK_LIB("Gdi32.lib", "cairo", PHP_CAIRO + "\\lib")) {
+                //AC_DEFINE("HAVE_WIN32_FONT", 1);
                 //ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_WIN32_FONT");
-			}
+            }
 
-			EXTENSION("cairo", PHP_CAIRO_SOURCES);
-	        ADD_EXTENSION_DEP("cairo", "eos_datastructures");
+            EXTENSION("cairo", PHP_CAIRO_SOURCES);
+            ADD_EXTENSION_DEP("cairo", "eos_datastructures");
 
-			AC_DEFINE("HAVE_CAIRO", 1);
-			PHP_INSTALL_HEADERS("ext/cairo", "src/php_cairo_api.h");
-		} else {
-			WARNING('Could not find cairo.lib or cairo_a.lib; skipping');
-		}
-	} else {
-		WARNING('Could not find cairo.h; skipping');
-	}
+            AC_DEFINE("HAVE_CAIRO", 1);
+            PHP_INSTALL_HEADERS("ext/cairo", "src/php_cairo_api.h");
+        } else {
+            WARNING('Could not find cairo.lib or cairo_a.lib; skipping');
+        }
+    } else {
+        WARNING('Could not find cairo.h; skipping');
+    }
 }

--- a/config.w32
+++ b/config.w32
@@ -19,11 +19,11 @@ if (PHP_CAIRO != "no") {
 			}
 			if (CHECK_LIB("freetype_a.lib", "cairo", PHP_CAIRO + "\\lib")) {
 				CHECK_HEADER_ADD_INCLUDE("freetype/freetype.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true);
-				//AC_DEFINE("HAVE_FREETYPE", 1);
-                //ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_FREETYPE");
+				AC_DEFINE("HAVE_FREETYPE", 1);
+                ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_FREETYPE");
                 if (CHECK_LIB("fontconfig.lib", "cairo", PHP_CAIRO + "\\lib") &&
                     CHECK_HEADER_ADD_INCLUDE("fontconfig/fontconfig.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true)) {
-                    //AC_DEFINE("CAIRO_HAS_FT_FONT", 1);
+                    AC_DEFINE("CAIRO_HAS_FT_FONT", 1);
                 }
             }
             if (CHECK_LIB("Gdi32.lib", "cairo", PHP_CAIRO + "\\lib")) {
@@ -43,11 +43,11 @@ if (PHP_CAIRO != "no") {
             }
             if (CHECK_LIB("freetype_a.lib", "cairo", PHP_CAIRO + "\\lib")) {
                 CHECK_HEADER_ADD_INCLUDE("freetype/freetype.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true);
-                //AC_DEFINE("HAVE_FREETYPE", 1);
-                //ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_FREETYPE");
+                AC_DEFINE("HAVE_FREETYPE", 1);
+                ADD_FLAG("CFLAGS_CAIRO", "/D HAVE_FREETYPE");
                 if (CHECK_LIB("fontconfig.lib", "cairo", PHP_CAIRO + "\\lib") &&
                     CHECK_HEADER_ADD_INCLUDE("fontconfig/fontconfig.h", "CFLAGS_CAIRO", PHP_CAIRO + "\\include", null, true)) {
-                    //AC_DEFINE("CAIRO_HAS_FT_FONT", 1);
+                    AC_DEFINE("CAIRO_HAS_FT_FONT", 1);
                 }
             }
             if (CHECK_LIB("Gdi32.lib", "cairo", PHP_CAIRO + "\\lib")) {

--- a/src/cairo.c
+++ b/src/cairo.c
@@ -28,6 +28,23 @@
 ZEND_BEGIN_ARG_INFO(Cairo_version_args, ZEND_SEND_BY_VAL)
 ZEND_END_ARG_INFO()
 
+#if defined(CAIRO_HAS_FT_FONT) && defined(HAVE_FREETYPE)
+
+const char* php_cairo_get_ft_error(int error) {
+	int i;
+	php_cairo_ft_error *current_error = php_cairo_ft_errors;
+
+	while (current_error->err_msg != NULL) {
+		if (current_error->err_code == error) {
+			return current_error->err_msg;
+		}
+		current_error++;
+	}
+	return NULL;
+}
+
+#endif
+
 /* {{{ proto int Cairo\version(void) 
        Returns an integer version number of the cairo library being used */
 PHP_FUNCTION(version)

--- a/src/cairo.c
+++ b/src/cairo.c
@@ -88,7 +88,7 @@ PHP_MINIT_FUNCTION(cairo)
 #if defined(CAIRO_HAS_QUARTZ_FONT)
         PHP_MINIT(cairo_quartz_font)(INIT_FUNC_ARGS_PASSTHRU);
 #endif
-#if defined(CAIRO_HAS_WIN32_FONT)
+#if defined(CAIRO_HAS_WIN32_FONT) && defined(HAVE_WIN32_FONT)
         PHP_MINIT(cairo_win32_font)(INIT_FUNC_ARGS_PASSTHRU);
 #endif
         PHP_MINIT(cairo_surface)(INIT_FUNC_ARGS_PASSTHRU);

--- a/src/php_cairo_api.h
+++ b/src/php_cairo_api.h
@@ -1,0 +1,204 @@
+/*
+  +----------------------------------------------------------------------+
+  | PHP Version 5                                                        |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1997-2014 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Elizabeth Smith <auroraeosrose@php.net>                      |
+  |         Michael Maclean <mgdm@php.net>                               |
+  |         Akshat Gupta <g.akshat@gmail.com>                            |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef PHP_CAIRO_API_H
+#define PHP_CAIRO_API_H
+
+/* Public C api for use by other extensions */
+
+#include <php.h>
+#include <cairo.h>
+
+#define PHP_CAIRO_API_VERSION "1.0.0"
+
+/* Cairo object stuff */
+typedef struct _stream_closure {
+	php_stream *stream;
+    zend_bool owned_stream;
+#ifdef ZTS
+	TSRMLS_D;
+#endif
+} stream_closure;
+
+typedef struct _cairo_glyph_object {
+	zend_object std;
+	cairo_glyph_t *glyph;
+} cairo_glyph_object;
+
+typedef struct _cairo_context_object {
+	zend_object std;
+	zval *surface;
+	zval *matrix;
+	zval *pattern;
+	zval *font_face;
+	zval *font_matrix;
+	zval *font_options;
+	zval *scaled_font;
+	cairo_t *context;
+} cairo_context_object;
+
+typedef struct _cairo_pattern_object {
+	zend_object std;
+	zval *matrix;
+	zval *surface;
+	cairo_pattern_t *pattern;
+} cairo_pattern_object;
+
+typedef struct _cairo_surface_object {
+	zend_object std;
+	cairo_surface_t *surface;
+	char * buffer;
+	stream_closure *closure;
+	zval *parent_zval;
+} cairo_surface_object;
+
+typedef struct _cairo_matrix_object {
+	zend_object std;
+	cairo_matrix_t *matrix;
+} cairo_matrix_object;
+
+typedef struct _cairo_path_object {
+	zend_object std;
+	cairo_path_t *path;
+} cairo_path_object;
+
+typedef struct _cairo_scaled_font_object {
+	zend_object std;
+	zval *font_face;
+	zval *font_options;
+	zval *matrix;
+	zval *ctm;
+	cairo_scaled_font_t *scaled_font;
+} cairo_scaled_font_object;
+
+typedef struct _cairo_font_face_object {
+	zend_object std;
+	cairo_font_face_t *font_face;
+} cairo_font_face_object;
+
+typedef struct _cairo_font_options_object {
+	zend_object std;
+	cairo_font_options_t *font_options;
+} cairo_font_options_object;
+
+
+
+/* Exported functions for PHP Cairo API */
+extern void php_cairo_throw_exception(cairo_status_t status TSRMLS_DC);
+extern void php_cairo_trigger_error(cairo_status_t status TSRMLS_DC);
+extern zend_class_entry* php_cairo_get_surface_ce(cairo_surface_t *surface TSRMLS_DC);
+extern zend_class_entry* php_cairo_get_pattern_ce(cairo_pattern_t *pattern TSRMLS_DC);
+extern zend_class_entry* php_cairo_get_context_ce();
+extern zend_class_entry* php_cairo_get_fontface_ce();
+extern zend_class_entry* php_cairo_get_fontoptions_ce();
+extern zend_class_entry* php_cairo_get_path_ce();
+
+/* Wrapped internal cairo functionality to avoid having to link against cairo lib as well as this extension */
+extern cairo_font_options_t* php_cairo_font_options_copy(const cairo_font_options_t *);
+extern cairo_t * php_cairo_context_reference(cairo_t *context);
+
+/* Helper for FreeType etc */
+#if defined(CAIRO_HAS_FT_FONT) && defined(HAVE_FREETYPE)
+const char* php_cairo_get_ft_error(int error);
+#endif
+
+/* Helpers to make fetching internal objects work right with extended classes */
+static inline cairo_context_object* cairo_context_object_get(zval *zobj TSRMLS_DC)
+{
+    cairo_context_object *pobj = zend_object_store_get_object(zobj TSRMLS_CC);
+    if (pobj->context == NULL) {
+		php_error(E_ERROR, "Internal context object missing in %s wrapper, you must call parent::__construct in extended classes", Z_OBJCE_P(zobj)->name);
+    }
+    return pobj;
+}
+
+static inline cairo_path_object* cairo_path_object_get(zval *zobj TSRMLS_DC)
+{
+    cairo_path_object *pobj = zend_object_store_get_object(zobj TSRMLS_CC);
+    if (pobj->path == NULL) {
+		php_error(E_ERROR, "Internal path object missing in %s wrapper, you must call parent::__construct in extended classes", Z_OBJCE_P(zobj)->name);
+    }
+    return pobj;
+}
+
+static inline cairo_pattern_object* cairo_pattern_object_get(zval *zobj TSRMLS_DC)
+{
+    cairo_pattern_object *pobj = zend_object_store_get_object(zobj TSRMLS_CC);
+    if (pobj->pattern == NULL) {
+        php_error(E_ERROR, "Internal pattern object missing in %s wrapper, you must call parent::__construct in extended classes", Z_OBJCE_P(zobj)->name);
+    }
+    return pobj;
+}
+
+static inline cairo_matrix_object* cairo_matrix_object_get(zval *zobj TSRMLS_DC)
+{
+    cairo_matrix_object *mobj = zend_object_store_get_object(zobj TSRMLS_CC);
+    if (mobj->matrix == NULL) {
+        php_error(E_ERROR, "Internal matrix object missing in %s wrapper, you must call parent::__construct in extended classes", Z_OBJCE_P(zobj)->name);
+    }
+    return mobj;
+}
+
+static inline cairo_surface_object* cairo_surface_object_get(zval *zobj TSRMLS_DC)
+{
+    cairo_surface_object *pobj = zend_object_store_get_object(zobj TSRMLS_CC);
+    if (pobj->surface == NULL) {
+        php_error(E_ERROR, "Internal surface object missing in %s wrapper, you must call parent::__construct in extended classes", Z_OBJCE_P(zobj)->name);
+    }
+    return pobj;
+}
+
+static inline cairo_font_face_object* cairo_font_face_object_get(zval *zobj TSRMLS_DC)
+{
+    cairo_font_face_object *pobj = zend_object_store_get_object(zobj TSRMLS_CC);
+    if (pobj->font_face == NULL) {
+        php_error(E_ERROR, "Internal font face object missing in %s wrapper, you must call parent::__construct in extended classes", Z_OBJCE_P(zobj)->name);
+    }
+    return pobj;
+}
+
+static inline cairo_scaled_font_object* cairo_scaled_font_object_get(zval *zobj TSRMLS_DC)
+{
+    cairo_scaled_font_object *pobj = zend_object_store_get_object(zobj TSRMLS_CC);
+    if (pobj->scaled_font == NULL) {
+        php_error(E_ERROR, "Internal scaled font object missing in %s wrapper, you must call parent::__construct in extended classes", Z_OBJCE_P(zobj)->name);
+    }
+    return pobj;
+}
+
+static inline cairo_font_options_object* cairo_font_options_object_get(zval *zobj TSRMLS_DC)
+{
+    cairo_font_options_object *pobj = zend_object_store_get_object(zobj TSRMLS_CC);
+    if (pobj->font_options == NULL) {
+        php_error(E_ERROR, "Internal font options object missing in %s wrapper, you must call parent::__construct in extended classes", Z_OBJCE_P(zobj)->name);
+    }
+    return pobj;
+}
+
+#endif /* PHP_CAIRO_API_H */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/src/php_cairo_internal.h
+++ b/src/php_cairo_internal.h
@@ -217,7 +217,7 @@ PHP_MINIT_FUNCTION(cairo_ft_font);
 #if defined(CAIRO_HAS_QUARTZ_FONT)
 PHP_MINIT_FUNCTION(cairo_quartz_font);
 #endif
-#if defined(CAIRO_HAS_WIN32_FONT)
+#if defined(CAIRO_HAS_WIN32_FONT) && defined(HAVE_WIN32_FONT)
 PHP_MINIT_FUNCTION(cairo_win32_font);
 #endif
 PHP_MINIT_FUNCTION(cairo_surface);

--- a/src/win32_font.c
+++ b/src/win32_font.c
@@ -85,6 +85,13 @@ static zend_class_entry *ce_cairo_win32fontpitch;
 static zend_class_entry *ce_cairo_win32fontfamily;
 static zend_object_handlers cairo_win32_font_face_object_handlers;
 
+/**
+ * CairoWin32FontFace::__construct takes 1 optional argument
+ */
+ZEND_BEGIN_ARG_INFO_EX(CairoWin32FontFace_construct_args, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
+    ZEND_ARG_INFO(0, font_options)
+ZEND_END_ARG_INFO()
+
 /* {{{ proto CairoWin32FontFace::__construct([array font_options])
        Creates a new font face for the Win32 backend */
 PHP_METHOD(CairoWin32FontFace, __construct)


### PR DESCRIPTION
Together with https://github.com/eosforphp/datastructures/pulls this PR makes it possible to compile php_cairo.dll for PHP7.0 on Windows.

The win32 fonts and freetype fonts do not work yet.

Compilation for PHP 7.1 fails because of this issue in the dependency reported by @swen100 
https://github.com/eosforphp/datastructures/issues/1